### PR TITLE
Update declarations.tex

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2533,7 +2533,7 @@ namespace R {
 \end{example}
 
 \pnum
-If a \tcode{friend} declaration in a non-local class first declares a
+If a \tcode{friend} declaration in a non-local class declares a
 class, function, class template or function template\footnote{this implies that the name of the class or function is unqualified.}
 the friend is a member of the innermost enclosing
 namespace. The \tcode{friend} declaration does not by itself make the name


### PR DESCRIPTION
The word **first** is confusing and unnecessary in [namespace.memdef]/3. It gives the impression that if the name in the `friend` declaration is **not** the first in its TU, the `friend` will not need to be a member of the innermost namespace, which is clearly incorrect as the snippet below shows:

`void f();
namespace A {
   struct S {
      friend void f();
   };
}`

The name `f` is **not** first declared in the `friend` declaration. Nevertheless, the snippet will compile, only if the function `f` is declared in namespace `A`, either before or after the friend declaration.